### PR TITLE
Add URL handling and browsing functionality  

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/go-playground/validator v9.31.0+incompatible
 	github.com/muesli/reflow v0.3.0
 	github.com/nxadm/tail v1.4.11
+	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c
 	github.com/rs/xid v1.6.0
 	github.com/spf13/cobra v1.8.1
 	gopkg.in/yaml.v2 v2.4.0

--- a/go.sum
+++ b/go.sum
@@ -73,6 +73,8 @@ github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWb
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/nxadm/tail v1.4.11 h1:8feyoE3OzPrcshW5/MJ4sGESc5cqmGkGCWlco4l0bqY=
 github.com/nxadm/tail v1.4.11/go.mod h1:OTaG3NK980DZzxbRq6lEuzgU+mug70nY11sMd4JXXHc=
+github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c h1:+mdjkGKdHQG3305AYmdv1U2eRNDiU2ErMBj1gwrq8eQ=
+github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c/go.mod h1:7rwL4CYBLnjLxUqIJNnCWiEdr3bn6IUYi15bNlnbCCU=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rivo/uniseg v0.1.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
@@ -96,6 +98,7 @@ golang.org/x/sync v0.10.0 h1:3NQrjDixjgGwUOCaF8w2+VYHv0Ve/vGYSbdkTa98gmQ=
 golang.org/x/sync v0.10.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
 golang.org/x/sys v0.0.0-20210809222454-d867a43fc93e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220908164124-27713097b956/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.29.0 h1:TPYlXGxvx1MGTn2GiZDhnjPA9wZzZeGKHHmKhHYvgaU=
 golang.org/x/sys v0.29.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -24,10 +24,10 @@ const Key KeyType = "config"
 type Config struct {
 	LogWriter io.Writer `yaml:"-"`
 
-	Site   Site   `yaml:"site"`
+	Blog   Blog   `yaml:"blog"`
+	Hugo   Hugo   `yaml:"hugo"`
 	Editor string `yaml:"editor"`
 	Open   string `yaml:"open_command"`
-	Hugo   Hugo   `yaml:"hugo"`
 }
 
 var validate *validator.Validate
@@ -41,9 +41,10 @@ type configError struct {
 
 type parser struct{}
 
-type Site struct {
-	Name string `yaml:"name"`
-	URL  string `yaml:"url"`
+type Blog struct {
+	Name    string `yaml:"name"`
+	URL     string `yaml:"url"`
+	DevPort int    `yaml:"dev_port"`
 }
 
 type Hugo struct {
@@ -54,15 +55,16 @@ type Hugo struct {
 
 func (p parser) getDefaultConfig() Config {
 	return Config{
-		Site: Site{
-			Name: "My site",
-			URL:  "https://example.com",
+		Blog: Blog{
+			Name:    "My site",
+			URL:     "https://example.com",
+			DevPort: 1313,
 		},
-		Editor: "vim",
-		Open:   "open",
 		Hugo: Hugo{
 			Command: "hugo server",
 		},
+		Editor: "vim",
+		Open:   "open",
 	}
 }
 


### PR DESCRIPTION
## Summary  
This PR introduces support for generating and opening article URLs in both production and development environments. Additionally, it refactors the configuration structure to better separate blog and Hugo settings.  

## Changes  
- **URL Handling for Articles**  
  - Introduced `Article.URL()` and `Article.DevURL()` to generate URLs based on the blog configuration.  
  - Defined a constant `LocalHost` for development URLs.  

- **New Key Bindings for Browsing**  
  - `b`: Open the article in the browser using its production URL.  
  - `B`: Open the article in the browser using its development URL.  

- **Refactored Configuration**  
  - Renamed `Site` struct to `Blog`, updating relevant fields.  
  - Added `DevPort` to `Blog` for development server configuration.  
  - Updated `Posts()` to accept `config.Config` instead of root/content directories separately.  

- **UI Improvements**  
  - Updated `list.Title` to use `c.Blog.Name`.  
  - Adjusted help keys to include the new browse commands.  

## Dependencies  
- Added `github.com/pkg/browser` to open URLs in the default web browser.  

## Motivation  
These changes improve navigation efficiency by allowing users to quickly open articles in a browser while working in the TUI. The configuration refactor also improves clarity and maintainability.  

