### PR TITLE
Make draft symbol configurable

### DIFF
--- a/internal/blog/blog.go
+++ b/internal/blog/blog.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/babarot/blog/internal/config"
 	"github.com/charmbracelet/bubbles/list"
+	"github.com/charmbracelet/lipgloss"
 	"gopkg.in/yaml.v2"
 )
 
@@ -56,9 +57,13 @@ func (p Article) Description() string {
 
 func (p Article) Title() string {
 	var suffix string
+
 	if p.Meta.Draft {
-		suffix = " ::Draft"
+		draftSuffix := p.config.Draft.Suffix
+		draftStyle := lipgloss.NewStyle().Foreground(lipgloss.Color(p.config.Draft.Color))
+		suffix = draftStyle.Render(" " + draftSuffix)
 	}
+
 	return p.Meta.Title + suffix
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -42,9 +42,15 @@ type configError struct {
 type parser struct{}
 
 type Blog struct {
-	Name    string `yaml:"name"`
-	URL     string `yaml:"url"`
-	DevPort int    `yaml:"dev_port"`
+	Name    string      `yaml:"name"`
+	URL     string      `yaml:"url"`
+	DevPort int         `yaml:"dev_port"`
+	Draft   DraftConfig `yaml:"draft"`
+}
+
+type DraftConfig struct {
+	Suffix string `yaml:"suffix"`
+	Color  string `yaml:"color"`
 }
 
 type Hugo struct {
@@ -59,6 +65,10 @@ func (p parser) getDefaultConfig() Config {
 			Name:    "My site",
 			URL:     "https://example.com",
 			DevPort: 1313,
+			Draft: DraftConfig{
+				Suffix: "::Draft",
+				Color:  "#5FB458",
+			},
 		},
 		Hugo: Hugo{
 			Command: "hugo server",


### PR DESCRIPTION
## WHAT

```yaml
blog:
  name: tellme.tokyo
  url: https://tellme.tokyo
  dev_port: 1313

  # New!
  draft: 
    color: "#5FB458"
    suffix: "::Draft"
```

## WHY

To make it stand out with what you like

![CleanShot 2025-02-23 at 11 34 56](https://github.com/user-attachments/assets/0c581dcd-220f-47fb-a14b-2f30ae6ae8f5)

